### PR TITLE
Fix tag for container image, add details to README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 VERSION ?=4.10
 # Default image tag
 
-SIDECAR_IMG ?= quay.io/redhat-cne/cloud-event-proxy:$(VERSION)
+SIDECAR_IMG ?= quay.io/redhat-cne/cloud-event-proxy:release-$(VERSION)
 CONSUMER_IMG ?= quay.io/redhat-cne/cloud-event-consumer:release-$(VERSION)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
@@ -30,9 +30,9 @@ KUSTOMIZE=$(shell which kustomize)
 endif
 
 deploy:kustomize
-	cd ./manifests && $(KUSTOMIZE) edit set image cloud-event-sidecar=${SIDECAR_IMG} && $(KUSTOMIZE) && $(KUSTOMIZE) edit set image cloud-event-consumer=${CONSUMER_IMG}
+	cd ./manifests && $(KUSTOMIZE) edit set image cloud-event-sidecar=${SIDECAR_IMG} && $(KUSTOMIZE) edit set image cloud-event-consumer=${CONSUMER_IMG}
 	$(KUSTOMIZE) build ./manifests | kubectl apply -f -
 
 undeploy:kustomize
-	cd ./manifests && $(KUSTOMIZE) edit set image cloud-event-sidecar=${SIDECAR_IMG} && $(KUSTOMIZE)  && $(KUSTOMIZE) edit set image cloud-event-consumer=${CONSUMER_IMG}
+	cd ./manifests && $(KUSTOMIZE) edit set image cloud-event-sidecar=${SIDECAR_IMG} && $(KUSTOMIZE) edit set image cloud-event-consumer=${CONSUMER_IMG}
 	$(KUSTOMIZE) build ./manifests | kubectl delete -f -

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # event-consumer
 Sample event consumer deployment
 
-###Set version
+### Set version
 
 ``export VERSION=4.9``
 
-###Deploy
+### Set transport host
+
+You may edit ``manifests/deployment.yaml`` to set a different transport host
+if it is deployed with a different namespace or interconnect name.
+
+### Deploy
 
 ``make deploy``
 
-###Undeploy
+### Undeploy
 
-```make undeploy```
+``make undeploy``

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -14,5 +14,5 @@ images:
   newName: quay.io/redhat-cne/cloud-event-consumer
   newTag: release-4.10
 - name: cloud-event-sidecar
-  newName: quay.io/openshift/origin-cloud-event-proxy
-  newTag: 4.10
+  newName: quay.io/redhat-cne/cloud-event-proxy
+  newTag: release-4.10


### PR DESCRIPTION
The tag for the quay.io/redhat-cne/cloud-event-proxy container image uses the release-<version> format.

Also adding a note to the README file to allow customizing the transport host and some format cleanup.