### PR TITLE
BUG OCPBUGS-7441: Match the O-RAN specification for the ocloudNotifications URI

### DIFF
--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -24,7 +24,7 @@ spec:
           image: cloud-event-consumer
           args:
             - "--local-api-addr=127.0.0.1:8089"
-            - "--api-path=/api/cloudNotifications/v1/"
+            - "--api-path=/api/ocloudNotifications/v1/"
             - "--api-addr=127.0.0.1:9089"
           env:
             - name: NODE_NAME


### PR DESCRIPTION
Adds the o in front of cloudNotifications URI
OCPBUGS-7441