### PR TITLE
Change default transport host to HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@ Sample event consumer deployment
 
 ### Set version
 
-``export VERSION=4.9``
+``export VERSION=4.12``
 
 ### Set transport host
 
-You may edit ``manifests/deployment.yaml`` to set a different transport host
-if it is deployed with a different namespace or interconnect name.
+You may need to edit ``manifests/deployment.yaml`` to set the right host name in the
+``--http-event-publishers`` argument. Also, change it if a different transport type
+(AMQ) is in use, or it runs on a different namespace or interconnect name.
 
 ### Deploy
 

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -40,7 +40,8 @@ spec:
           args:
             - "--metrics-addr=127.0.0.1:9091"
             - "--store-path=/store"
-            - "--transport-host=amqp://amq-router.amq-router.svc.cluster.local"
+            - "--transport-host=consumer-events-subscription-service.cloud-events.svc.cluster.local:9043"
+            - "--http-event-publishers=ptp-event-publisher-service-HOSTNAME.openshift-ptp.svc.cluster.local:9043"
             - "--api-port=9089"
           env:
             - name: NODE_NAME
@@ -57,6 +58,8 @@ spec:
           ports:
             - name: metrics-port
               containerPort: 9091
+            - name: sub-port
+              containerPort: 9043
         - name: kube-rbac-proxy
           image: quay.io/coreos/kube-rbac-proxy:v0.5.0
           args:

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -12,7 +12,7 @@ replicas:
 images:
 - name: cloud-event-consumer
   newName: quay.io/redhat-cne/cloud-event-consumer
-  newTag: release-4.10
+  newTag: release-4.12
 - name: cloud-event-sidecar
   newName: quay.io/redhat-cne/cloud-event-proxy
-  newTag: release-4.10
+  newTag: release-4.12

--- a/manifests/service.yaml
+++ b/manifests/service.yaml
@@ -17,6 +17,26 @@ spec:
     app: consumer
   type: ClusterIP
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    service.alpha.openshift.io/serving-cert-secret-name: sidecar-consumer-secret
+  name: consumer-events-subscription-service
+  namespace: cloud-events
+  labels:
+    app: consumer-service
+spec:
+  ports:
+    - name: sub-port
+      port: 9043
+  selector:
+    app: consumer
+  clusterIP: None
+  sessionAffinity: None
+  type: ClusterIP
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
The default transport host needs to be HTTP, since AMQ will be deprecated in the future. This commit adds the required changes to do so, and changes the default OpenShift version to 4.12 in the kustomization.yaml file.