### PR TITLE
Fix NODE_NAME compatibility, add OCP 4.16 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Sample event consumer deployment
 
 ### Set transport host
 
-You may need to edit ``manifests/deployment.yaml`` to set the right host name in the
-``--http-event-publishers`` argument. Also, change it if a different transport type
+You may need to edit ``manifests/deployment.yaml`` if deploying on OpenShift 4.16
+or later (see comments in file). Also, change it if a different transport type
 (AMQ) is in use, or it runs on a different namespace or interconnect name.
 
 ### Deploy

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -26,6 +26,8 @@ spec:
             - "--local-api-addr=127.0.0.1:8089"
             - "--api-path=/api/ocloudNotifications/v1/"
             - "--api-addr=127.0.0.1:9089"
+            # Uncomment the following line if deploying on OCP 4.16 or later
+            # - "--http-event-publishers=ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"
           env:
             - name: NODE_NAME
               valueFrom:
@@ -41,17 +43,13 @@ spec:
             - "--metrics-addr=127.0.0.1:9091"
             - "--store-path=/store"
             - "--transport-host=consumer-events-subscription-service.cloud-events.svc.cluster.local:9043"
-            - "--http-event-publishers=ptp-event-publisher-service-HOSTNAME.openshift-ptp.svc.cluster.local:9043"
+            - "--http-event-publishers=ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043"
             - "--api-port=9089"
           env:
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: NODE_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
           volumeMounts:
             - name: pubsubstore
               mountPath: /store


### PR DESCRIPTION
We need to remove the NODE_IP env var if we want the sidecar and consumer containers to properly replace NODE_NAME in the transport host URL. Also, for OCP 4.16 and later, the transport host URL needs to be added to the cloud-event-consumer container arguments.